### PR TITLE
Move ts-proto to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.8.4",
-    "deepmerge": "^4.2.2",
-    "ts-proto": "^1.138.0"
+    "deepmerge": "^4.2.2"
   },
   "devDependencies": {
     "@jsdevtools/npm-publish": "^1.4.3",
@@ -45,6 +44,7 @@
     "patch-package": "^6.5.1",
     "rimraf": "^4.1.0",
     "ts-jest": "^29.0.5",
+    "ts-proto": "^1.138.0",
     "ts-node": "^10.9.1",
     "typescript": "4.8.4"
   },


### PR DESCRIPTION
Since you publish to NPM the generated folder, there is no good reason to download this lib which  brings 70MB of deps,

<img width="310" alt="image" src="https://user-images.githubusercontent.com/9304194/214236333-0213c75d-79c6-454d-bf95-0c9f12b30070.png">
